### PR TITLE
Error responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reststate/client",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A vanilla JS client for JSON:API services",
   "main": "index.js",
   "repository": "git@github.com:reststate/reststate-client.git",

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -15,7 +15,11 @@ const relatedResourceUrl = ({ parent, relationship }) =>
 const extractData = response => response.data;
 
 const extractErrorResponse = error => {
-  throw error.response;
+  if (error && error.response) {
+    throw error.response;
+  } else {
+    throw error;
+  }
 };
 
 class Resource {

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -14,6 +14,10 @@ const relatedResourceUrl = ({ parent, relationship }) =>
 
 const extractData = response => response.data;
 
+const extractErrorResponse = error => {
+  throw error.response;
+};
+
 class Resource {
   constructor({ name, httpClient }) {
     this.name = name;
@@ -29,32 +33,45 @@ class Resource {
       url = `${this.name}?${getOptionsQuery(options)}`;
     }
 
-    return this.api.get(url).then(extractData);
+    return this.api
+      .get(url)
+      .then(extractData)
+      .catch(extractErrorResponse);
   }
 
   find({ id, options } = {}) {
     const url = `${this.name}/${id}?${getOptionsQuery(options)}`;
 
-    return this.api.get(url).then(extractData);
+    return this.api
+      .get(url)
+      .then(extractData)
+      .catch(extractErrorResponse);
   }
 
   where({ filter, options } = {}) {
     const queryString = filterQueryString(filter);
     return this.api
       .get(`${this.name}?${queryString}&${getOptionsQuery(options)}`)
-      .then(extractData);
+      .then(extractData)
+      .catch(extractErrorResponse);
   }
 
   related({ parent, relationship = this.name, options }) {
     const baseUrl = relatedResourceUrl({ parent, relationship });
     const url = `${baseUrl}?${getOptionsQuery(options)}`;
-    return this.api.get(url).then(extractData);
+    return this.api
+      .get(url)
+      .then(extractData)
+      .catch(extractErrorResponse);
   }
 
   create(partialRecord) {
     const record = Object.assign({}, partialRecord, { type: this.name });
     const requestData = { data: record };
-    return this.api.post(`${this.name}`, requestData).then(extractData);
+    return this.api
+      .post(`${this.name}`, requestData)
+      .then(extractData)
+      .catch(extractErrorResponse);
   }
 
   update(record) {
@@ -62,11 +79,12 @@ class Resource {
     const requestData = { data: record };
     return this.api
       .patch(`${this.name}/${record.id}`, requestData)
-      .then(extractData);
+      .then(extractData)
+      .catch(extractErrorResponse);
   }
 
   delete({ id }) {
-    return this.api.delete(`${this.name}/${id}`);
+    return this.api.delete(`${this.name}/${id}`).catch(extractErrorResponse);
   }
 }
 

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -54,13 +54,15 @@ describe('Resource', () => {
       expect(api.get).toHaveBeenCalledWith(url);
     });
 
-    it('rejects upon error', () => {
-      const error = { dummy: 'data' };
-      api.get.mockRejectedValue(error);
+    it('rejects with the response upon error', () => {
+      const errorResponse = { dummy: 'data' };
+      api.get.mockRejectedValue({ response: errorResponse });
 
       const result = resource.all();
 
-      expect(result).rejects.toEqual(error);
+      return result.catch(error => {
+        expect(error).toEqual(errorResponse);
+      });
     });
   });
 
@@ -84,13 +86,15 @@ describe('Resource', () => {
       expect(api.get).toHaveBeenCalledWith('widgets/1?include=comments');
     });
 
-    it('rejects upon error', () => {
-      const error = { dummy: 'data' };
-      api.get.mockRejectedValue(error);
+    it('rejects with the response upon error', () => {
+      const errorResponse = { dummy: 'data' };
+      api.get.mockRejectedValue({ response: errorResponse });
 
       const result = resource.find({ id: 1 });
 
-      expect(result).rejects.toEqual(error);
+      return result.catch(error => {
+        expect(error).toEqual(errorResponse);
+      });
     });
   });
 
@@ -120,13 +124,15 @@ describe('Resource', () => {
       );
     });
 
-    it('rejects upon error', () => {
-      const error = { dummy: 'data' };
-      api.get.mockRejectedValue(error);
+    it('rejects with the response upon error', () => {
+      const errorResponse = { dummy: 'data' };
+      api.get.mockRejectedValue({ response: errorResponse });
 
       const result = resource.where({ filter });
 
-      expect(result).rejects.toEqual(error);
+      return result.catch(error => {
+        expect(error).toEqual(errorResponse);
+      });
     });
   });
 
@@ -166,13 +172,15 @@ describe('Resource', () => {
       expect(api.get).toHaveBeenCalledWith('users/1/widgets?include=comments');
     });
 
-    it('rejects upon error', () => {
-      const error = { dummy: 'data' };
-      api.get.mockRejectedValue(error);
+    it('rejects with the response upon error', () => {
+      const errorResponse = { dummy: 'data' };
+      api.get.mockRejectedValue({ response: errorResponse });
 
       const result = resource.related({ parent });
 
-      expect(result).rejects.toEqual(error);
+      return result.catch(error => {
+        expect(error).toEqual(errorResponse);
+      });
     });
   });
 
@@ -194,13 +202,15 @@ describe('Resource', () => {
       return expect(result).resolves.toEqual(responseBody);
     });
 
-    it('rejects upon error', () => {
-      const error = { dummy: 'data' };
-      api.post.mockRejectedValue(error);
+    it('rejects with the response upon error', () => {
+      const errorResponse = { dummy: 'data' };
+      api.post.mockRejectedValue({ response: errorResponse });
 
       const result = resource.create(record);
 
-      return expect(result).rejects.toEqual(error);
+      return result.catch(error => {
+        expect(error).toEqual(errorResponse);
+      });
     });
   });
 
@@ -215,31 +225,37 @@ describe('Resource', () => {
       return expect(result).resolves.toEqual(responseBody);
     });
 
-    it('rejects upon error', () => {
-      const error = { dummy: 'data' };
-      api.patch.mockRejectedValue(error);
+    it('rejects with the response upon error', () => {
+      const errorResponse = { dummy: 'data' };
+      api.patch.mockRejectedValue({ response: errorResponse });
 
       const result = resource.update(record);
 
-      return expect(result).rejects.toEqual(error);
+      return result.catch(error => {
+        expect(error).toEqual(errorResponse);
+      });
     });
   });
 
   describe('delete', () => {
     it('can delete a record', () => {
+      api.delete.mockResolvedValue();
+
       const result = resource.delete(record);
 
       expect(api.delete).toHaveBeenCalledWith('widgets/1');
       return result; // confirm it resolves
     });
 
-    it('rejects upon error', () => {
-      const error = { dummy: 'data' };
-      api.delete.mockRejectedValue(error);
+    it('rejects with the response upon error', () => {
+      const errorResponse = { dummy: 'data' };
+      api.delete.mockRejectedValue({ response: errorResponse });
 
       const result = resource.delete(record);
 
-      return expect(result).rejects.toEqual(error);
+      return result.catch(error => {
+        expect(error).toEqual(errorResponse);
+      });
     });
   });
 });

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -54,7 +54,7 @@ describe('Resource', () => {
       expect(api.get).toHaveBeenCalledWith(url);
     });
 
-    it('rejects with the response upon error', () => {
+    it('rejects with the response upon server error', () => {
       const errorResponse = { dummy: 'data' };
       api.get.mockRejectedValue({ response: errorResponse });
 
@@ -62,6 +62,17 @@ describe('Resource', () => {
 
       return result.catch(error => {
         expect(error).toEqual(errorResponse);
+      });
+    });
+
+    it('rejects with the bare error upon another kind of error error', () => {
+      const error = new Error('foo');
+      api.get.mockRejectedValue(error);
+
+      const result = resource.all();
+
+      return result.catch(e => {
+        expect(e).toEqual(error);
       });
     });
   });


### PR DESCRIPTION
When an error is returned from the server, reject with the response itself, not the wrapping object. This hides the details of Axios and gets the user closer to the data they want. We don't send back the data field itself, because we also want to expose the HTTP status.