### PR TITLE
Use modern module declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const ResourceClient = require('./src/Resource');
+import ResourceClient from './src/Resource';
 
-module.exports = { ResourceClient };
+export { ResourceClient };

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -106,4 +106,4 @@ class Resource {
   }
 }
 
-module.exports = Resource;
+export default Resource;


### PR DESCRIPTION
Assigning something to `module.exports`, which is a read-only property, is not valid in strict mode (`Assignment to read-only properties is not allowed in strict mode`). This error turns up when Babel transpiring this library to something a browser like IE11 can use. If modern module declarations are used instead (just like https://github.com/reststate/reststate-vuex does) this breaking issue can be avoided.