### PR TITLE
docs(README): fix doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const resource = new ResourceClient({
   httpClient: axios.create(...),
 });
 
-resource.loadAll()
+resource.all()
   .then(widgets => widgets);
 
 resource.create({
@@ -43,7 +43,7 @@ $ npm install --save @reststate/client
 import axios from 'axios';
 import { ResourceClient } from '@reststate/client';
 
-const token = ...;
+const token = "FILL_ME";
 
 const httpClient = axios.create({
   baseUrl: 'https://sandboxapi.codingitwrong.com',


### PR DESCRIPTION
- wrong method called
- "..." could be disrupting for newbies

By the way, could you also update the doc website? or tell me how to do? Most of methods are wrongly named/called like loadAll -> all (legacy names?)

Could you also specify what is "name" in a ResourceClient?

Thank you!