### PR TITLE
docs(README): typo on axios instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import { ResourceClient } from '@reststate/client';
 const token = ...;
 
 const httpClient = axios.create({
-  baseUrl: 'https://sandboxapi.codingitwrong.com',
+  baseURL: 'https://sandboxapi.codingitwrong.com',
   headers: {
     'Content-Type': 'application/vnd+api.json',
     'Authentication': `Bearer ${token}`,


### PR DESCRIPTION
It's not `baseUrl` but `baseURL`

https://axios.nuxtjs.org/options#baseurl or https://github.com/axios/axios/blob/master/README.md#request-config