### PR TITLE
Allow adding custom query string parameters

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -1,7 +1,11 @@
-function filterQueryString(obj) {
-  return Object.keys(obj)
-    .map(k => `filter[${k}]=${encodeURIComponent(obj[k])}`)
-    .join('&');
+function filterQueryString({ filter = {}, customFilter = {} }) {
+  const paramsFromFilter = Object.keys(filter).map(
+    k => `filter[${k}]=${encodeURIComponent(filter[k])}`,
+  );
+  const paramsFromCustomFilter = Object.keys(customFilter).map(
+    k => `filter${k}=${encodeURIComponent(customFilter[k])}`,
+  );
+  return [...paramsFromFilter, ...paramsFromCustomFilter].join('&');
 }
 
 const getOptionsQuery = (optionsObject = {}) =>
@@ -60,8 +64,8 @@ class Resource {
     return this.api.get(url).then(extractData).catch(extractErrorResponse);
   }
 
-  where({ filter, options } = {}) {
-    const queryString = filterQueryString(filter);
+  where({ filter, customFilter, options } = {}) {
+    const queryString = filterQueryString({ filter, customFilter });
     return this.api
       .get(`${this.name}?${queryString}&${getOptionsQuery(options)}`)
       .then(extractData)

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -128,6 +128,17 @@ describe('Resource', () => {
       return expect(result).resolves.toEqual(expectedResponse);
     });
 
+    it('can add custom query string parameters', () => {
+      api.get.mockResolvedValue();
+
+      const customFilter = {
+        '[foo][bar]': 'draft',
+      };
+      const result = resource.where({ customFilter });
+
+      expect(api.get).toHaveBeenCalledWith('widgets?filter[foo][bar]=draft&');
+    });
+
     it('can request included records', () => {
       const expectedResponse = { data: records };
       api.get.mockResolvedValue({ data: expectedResponse });


### PR DESCRIPTION
TODO: add documentation before merge

Fixes #148 

To customize how your filter params work, including setting up nested query "arrays", use the `.where({ customFilter })` named argument instead:

```
      const customFilter = {
        '[foo][bar]': 'draft',
      };
      const result = resource.where({ customFilter });
```

Results in query string arguments:

```
?filter[foo][bar]=draft
```

In other words, `filter` wraps your keys with `[]` because that's the most common scenario, but with `customFilter` you do your own wrapping with `[]`, so that you can nest them.